### PR TITLE
新增函数：`signMessage`

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -36,6 +36,46 @@ IWalletJS.enable().then((account) => {
     iost.signAndSend(ctx)
     ...
 })
+```
 
+## SignMessage
 
+```js
+// /^[1-9a-zA-Z]{1,11}$/
+const message = "a123456AZ";
+
+IWalletJS.enable().then((account) => {
+    if(account){
+        const iost = IWalletJS.newIOST(IOST)
+        iost.signMessage(message)
+            .on('pending', (pending) => {
+                console.log(pending, 'pending')
+                this.setState({
+                    isLoading: true,
+                    txHash: pending,
+                    result: ''
+                })
+            })
+            .on('success', (result) => {
+              // {
+              //      "algorithm": "xxx",
+              //      "public_key": "xxx",
+              //      "signature: "base64 format"
+              //      "message": "message"
+              // }
+                this.setState({
+                    isLoading: false,
+                    result: JSON.stringify(result)
+                })
+            })
+            .on('failed', (failed) => {
+                console.log(failed, 'failed')
+                this.setState({
+                    isLoading: false,
+                })
+            })
+    }else{
+        console.log('not login')
+    }
+})
 ```

--- a/public/app/scripts/ui/popup-index.js
+++ b/public/app/scripts/ui/popup-index.js
@@ -18,6 +18,7 @@ const i18n = {
     "Dapp_Cancel": "Cancel",
     "Dapp_Confirm": "Confirm",
     "Dapp_Tip3": "* If you add this contract to the white-list, it will allow you to sign directly when you initiate the same contract request to the same beneficiary, manual operation will be no longer applied.",
+    "Dapp_Message_Signature": "Message Signature Requested",
   },
   ko: {
     "Dapp_Unlock": "지금 잠금해제하기",
@@ -29,6 +30,7 @@ const i18n = {
     "Dapp_Cancel": "취소",
     "Dapp_Confirm": "확인",
     "Dapp_Tip3": "* If you add this contract to the white-list, it will allow you to sign directly when you initiate the same contract request to the same beneficiary, manual operation will be no longer applied.",
+    "Dapp_Message_Signature": "Message Signature Requested",
   },
   zh: {
     "Dapp_Unlock": "立即解锁",
@@ -40,6 +42,7 @@ const i18n = {
     "Dapp_Cancel": "取消",
     "Dapp_Confirm": "确认",
     "Dapp_Tip3": "* 如您将这个合约加入白名单，代表您允许您的账号在同一网站发起同一合约请求给同一收款方的情况下，直接给予签名，而不再进行手动授权。",
+    "Dapp_Message_Signature": "请求信息签名",
   },
 }
 
@@ -138,16 +141,23 @@ class AskPopup extends Component<Props> {
   render() {
     const { isAddWhitelist } = this.state
     const [contractAddress, abi, args = []] = this.txInfo
-
+    const hasSignMessage = abi === '@__SignMessage';
     return (
       <MultiAction txInfo={this.txInfo} slotIdx={this.slotIdx}/>
     )
     return (
       <div className="AskPopup">
         <header className="AskPopup__header">
-          <p className="title">{abi == 'transfer' ? this.onTransLocal('Dapp_Signature') : this.onTransLocal('Dapp_Authorization')}</p>
-          <p><span>{contractAddress}</span><span>-></span><span>{abi}</span></p>
-          <span class={isAddWhitelist?'active':''} onClick={this.onToggleWhiteList}>  {this.onTransLocal('Dapp_WhiteList')}</span>
+          <p className="title">{abi == 'transfer' ? this.onTransLocal('Dapp_Signature') : hasSignMessage ?  this.onTransLocal('Dapp_WhiteList'): this.onTransLocal('Dapp_Authorization')}</p>
+          {
+              hasSignMessage
+                  ?(<p><span>{this.onTransLocal('Dapp_Message_Signature')}</span></p>)
+                  :(<p><span>{contractAddress}</span><span>-></span><span>{abi}</span></p>)
+          }
+            {
+                hasSignMessage? null:(<span class={isAddWhitelist?'active':''} onClick={this.onToggleWhiteList}>  {this.onTransLocal('Dapp_WhiteList')}</span>)
+            }
+          {/*<span class={isAddWhitelist?'active':''} onClick={this.onToggleWhiteList}>  {this.onTransLocal('Dapp_WhiteList')}</span>*/}
         </header>
         <div className="AskPopup__container">
           {abi == 'transfer'?

--- a/public/app/scripts/ui/popup-multiAction.js
+++ b/public/app/scripts/ui/popup-multiAction.js
@@ -28,6 +28,7 @@ const i18n = {
     "Dapp_Tip1": "* Account authorization does not share your private key",
     "Dapp_Tip2": "* Current applications are developed by third parties, please pay attention to screening",
     "Dapp_Tip3": "* If you add this contract to the white-list, it will allow you to sign directly when you initiate the same contract request to the same beneficiary, manual operation will be no longer applied.",
+    "Dapp_Message_Signature": "Message Signature Requested",
   },
   ko: {
     "Transfer": "트랜스퍼",
@@ -53,6 +54,7 @@ const i18n = {
     "Dapp_Tip1": "* 계정 인증은 프라이빗 키를 공유하지 않습니다.",
     "Dapp_Tip2": "* 현재 응용 프로그램은 제 3 자에 의해 개발되었습니다. 스크리닝에 주의해 주세요.",
     "Dapp_Tip3": "* If you add this contract to the white-list, it will allow you to sign directly when you initiate the same contract request to the same beneficiary, manual operation will be no longer applied.",
+    "Dapp_Message_Signature": "Message Signature Requested",
   },
   zh: {
     "Transfer": "转账",
@@ -78,6 +80,7 @@ const i18n = {
     "Dapp_Tip1": "* 账户授权并不会共享您的私钥",
     "Dapp_Tip2": "* 当前应用为第三方开发，请注意甄别",
     "Dapp_Tip3": "* 如您将这个合约加入白名单，代表您允许您的账号在同一网站发起同一合约请求给同一收款方的情况下，直接给予签名，而不再进行手动授权。",
+    "Dapp_Message_Signature": "请求信息签名",
   },
 }
 
@@ -204,23 +207,34 @@ export default class extends Component {
     const { lang, tx: transaction, isAddWhitelist, iGASLimit, iGASPrice, showGasForm } = this.state
     const { tx, account } = transaction
     const hasTransfer = tx.actions.some(act => act.actionName === 'transfer')
+    const hasSignMessage = tx.actions.some(act => act.actionName === '@__SignMessage')
 
     return (
       <div className="multi-action">
         <div className="header">
-          <span
-            onClick={this.toggleWhiteList}
-            className={classnames('whitelist-btn', isAddWhitelist && 'active')}>
-            {transLocal(lang, 'Dapp_WhiteList')}
-          </span>
-          <h1 className="title">{transLocal(lang, hasTransfer ? 'Dapp_Signature' : 'Dapp_Authorization')}</h1>
+            {
+              hasSignMessage? null:
+                  (<span
+                      onClick={this.toggleWhiteList}
+                      className={classnames('whitelist-btn', isAddWhitelist && 'active')}>
+                      {transLocal(lang, 'Dapp_WhiteList')}
+                  </span>)
+            }
+          {/*<span*/}
+            {/*onClick={this.toggleWhiteList}*/}
+            {/*className={classnames('whitelist-btn', isAddWhitelist && 'active')}>*/}
+            {/*{transLocal(lang, 'Dapp_WhiteList')}*/}
+          {/*</span>*/}
+          <h1 className="title">{transLocal(lang, hasTransfer ? hasSignMessage?'Dapp_WhiteList':'Dapp_Signature' : 'Dapp_Authorization')}</h1>
           <p className="memo">{tx.actions.length} {transLocal(lang, tx.actions.length > 1 ? 'XActionsNeedYouPermissionS' : 'XActionsNeedYouPermission')}</p>
         </div>
         <div className="content">
           <section className="list">
             <ol>
-              {
-                tx.actions.map(act => (
+              {hasSignMessage
+                  ? null
+                  :
+                  tx.actions.map(act => (
                   <li key={act.contract}>{act.contract} <i className="arrow">-></i>  {act.actionName}</li>
                 ))
               }

--- a/src/constants/icon.js
+++ b/src/constants/icon.js
@@ -6,7 +6,7 @@ const iconSrc = {
   emogi: '/static/images/icon-token-emogi.png',
   idt: '/static/images/icon-token-idt.png',
   ifry: '/static/images/icon-token-ifry.png',
-  iost: '/static/images/logo3.png',
+  // iost: '/static/images/logo3.png',
   iplay: '/static/images/icon-token-iplay.svg',
   itopia: '/static/images/icon-token-itopia.svg',
   itrx: '/static/images/icon-token-itrx.svg',


### PR DESCRIPTION
描述：iwallet支持DApp请求调用签名任意的字符串，签名的字符串由DApp指定，签名方法返回签名后的结果给DApp。为了保证安全，该字符串限制必须全部为1-9a-zA-Z中的字符，并且字符串长度小于12。
不支持添加到白名单。